### PR TITLE
build(ci): 添加 Chocolatey、Multilingual App Toolkit 和 MSBuild 设置

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,6 +29,18 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
+    - name: Install Chocolatey
+      run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    
+    - name: Install Multilingual App Toolkit
+      run: choco install multilingualappstoolkit -y
+    
+    - name: Setup Visual Studio Build Tools
+      uses: microsoft/setup-msbuild@v2
+
     - name: Publish
       run: |
         .\publish.ps1


### PR DESCRIPTION
- 安装 Chocolatey 以支持后续软件包安装
- 安装 Multilingual App Toolkit 用于多语言应用开发
- 设置 Visual Studio Build Tools 以使用 MSBuild