### PR TITLE
ci: 更新 upload-artifact 动作版本

### DIFF
--- a/.github/workflows/winui3.yml
+++ b/.github/workflows/winui3.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Upload the app
     - name: Upload app
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Upload app
         path: ${{ env.Solution_Name }}\\bin


### PR DESCRIPTION
- 将 actions/upload-artifact 从 v2 升级到 v4
- 此更新可以提高构建产物上传的可靠性和效率