### PR TITLE
ci: 更新 GitHub Actions 和代码样式配置

### DIFF
--- a/.github/workflows/winui3.yml
+++ b/.github/workflows/winui3.yml
@@ -68,7 +68,7 @@ jobs:
         .\7z.ps1 ${{ github.ref_name }}
 
     - name: Release
-      uses: softprops/action-gh-release@v2.1.0
+      uses: softprops/action-gh-release@v2.2.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         tag_name: ${{ github.ref_name }}

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -13,6 +13,9 @@ dotnet_style_qualification_for_event = false:silent
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
 dotnet_code_quality_unused_parameters = all:suggestion
 dotnet_style_readonly_field = true:suggestion
+tab_width = 4
+indent_size = 4
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
 [*.cs]
 csharp_space_around_binary_operators = before_and_after
@@ -90,6 +93,8 @@ csharp_prefer_system_threading_lock = true:suggestion
 
 # CA1416: 验证平台兼容性
 dotnet_diagnostic.CA1416.severity = suggestion
+dotnet_diagnostic.MVVMTK0045.severity = suggestion
+csharp_indent_labels = one_less_than_current
 
 [*.vb]
 #### 命名样式 ####


### PR DESCRIPTION
- 将 softprops/action-gh-release 版本从 v2.1.0 升级到 v2.2.0
- 在 .editorconfig 中添加新的代码样式规则，包括缩进设置和标签缩进方式
- 为 MVVMTK0045 诊断设置建议严重性