### PR TITLE
refactor(converters): 将转换器类改为部分类

### DIFF
--- a/src/EasyTidy/Converters/Bool2Negation2VisibilityConverter.cs
+++ b/src/EasyTidy/Converters/Bool2Negation2VisibilityConverter.cs
@@ -2,7 +2,7 @@
 using Microsoft.UI.Xaml.Data;
 
 namespace EasyTidy.Converters;
-public class Bool2Negation2VisibilityConverter : IValueConverter
+public partial class Bool2Negation2VisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/EasyTidy/Converters/BoolToImageSourceConverter.cs
+++ b/src/EasyTidy/Converters/BoolToImageSourceConverter.cs
@@ -2,7 +2,7 @@
 using Microsoft.UI.Xaml.Media;
 
 namespace EasyTidy.Converters;
-public class BoolToImageSourceConverter : IValueConverter
+public partial class BoolToImageSourceConverter : IValueConverter
 {
     public ImageSource? TrueImage { get; set; }
     public ImageSource? FalseImage { get; set; }

--- a/src/EasyTidy/Converters/BoolToStringConverter.cs
+++ b/src/EasyTidy/Converters/BoolToStringConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EasyTidy.Converters;
 
-public class BoolToStringConverter : IValueConverter
+public partial class BoolToStringConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/EasyTidy/Converters/LineDashStrokeArrayConverter.cs
+++ b/src/EasyTidy/Converters/LineDashStrokeArrayConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Media;
 
 namespace EasyTidy.Converters;
 
-public class LineDashStrokeArrayConverter : IValueConverter
+public partial class LineDashStrokeArrayConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {


### PR DESCRIPTION
- 在 Bool2Negation2VisibilityConverter、BoolToImageSourceConverter、 BoolToStringConverter 和 LineDashStrokeArrayConverter 中使用 partial 关键字
- 为将来可能的代码分拆或扩展做准备